### PR TITLE
Fix wrong syntax in TypeScript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,9 +50,9 @@ export interface DatePickerProps<TValue extends Value> extends CalendarProps<TVa
 
 type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
-function DatePicker(props: Optional<DatePickerProps<Day>, 'value'>): React.ReactElement;
-function DatePicker(props: DatePickerProps<Day[]>): React.ReactElement;
-function DatePicker(props: DatePickerProps<DayRange>): React.ReactElement;
+declare function DatePicker(props: Optional<DatePickerProps<Day>, 'value'>): React.ReactElement;
+declare function DatePicker(props: DatePickerProps<Day[]>): React.ReactElement;
+declare function DatePicker(props: DatePickerProps<DayRange>): React.ReactElement;
 
 export default DatePicker;
 


### PR DESCRIPTION
This PR fixes the syntax error caused by f1c0fa34f4522d7bcb3fb0104a8f7a104204ced2. Related to #77. Maybe we should unpublish or deprecate version 1.1.1.