### PR TITLE
v2.1.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,8 +54,6 @@ declare function DatePicker(props: Optional<DatePickerProps<Day>, 'value'>): Rea
 declare function DatePicker(props: DatePickerProps<Day[]>): React.ReactElement;
 declare function DatePicker(props: DatePickerProps<DayRange>): React.ReactElement;
 
-export default DatePicker;
-
 export type Utils = {
   monthsList: string[];
   weekDaysList: string[];
@@ -70,3 +68,27 @@ export type Utils = {
 };
 
 export function utils(locale: string): Utils;
+
+export interface Locale {
+  months: string[];
+  weekDays: string[];
+  weekStartingIndex: number;
+  getToday: () => Day;
+  toNativeDate: () => Date;
+  getMonthLength: () => number;
+  transformDigit: () => (number | string);
+  nextMonth: string;
+  previousMonth: string;
+  openMonthSelector: string;
+  openYearSelector: string;
+  closeMonthSelector: string;
+  closeYearSelector: string;
+  from: string;
+  to: string;
+  defaultPlaceholder: string;
+  digitSeparator: string;
+  yearLetterSkip: number;
+  isRtl: boolean;
+}
+
+export default DatePicker;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modern-calendar-datepicker",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A modern, beautiful, customizable date picker for React",
   "main": "lib/index.js",
   "types": "index.d.ts",

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -2,7 +2,13 @@ import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { getDateAccordingToMonth, shallowClone, getValueType } from './shared/generalUtils';
-import { DAY_SHAPE, TYPE_SINGLE_DATE, TYPE_RANGE, TYPE_MUTLI_DATE } from './shared/constants';
+import {
+  DAY_SHAPE,
+  TYPE_SINGLE_DATE,
+  TYPE_RANGE,
+  TYPE_MUTLI_DATE,
+  LOCALE_SHAPE,
+} from './shared/constants';
 import { useLocaleUtils, useLocaleLanguage } from './shared/hooks';
 
 import { Header, MonthSelector, YearSelector, DaysList } from './components';
@@ -48,7 +54,7 @@ const Calendar = ({
   });
 
   const { getToday } = useLocaleUtils(locale);
-  const { weekDays: weekDaysList } = useLocaleLanguage(locale);
+  const { weekDays: weekDaysList, isRtl } = useLocaleLanguage(locale);
   const today = getToday();
 
   const createStateToggler = property => () => {
@@ -109,7 +115,7 @@ const Calendar = ({
 
   return (
     <div
-      className={`Calendar -noFocusOutline ${calendarClassName} -${locale}`}
+      className={`Calendar -noFocusOutline ${calendarClassName} -${isRtl ? 'rtl' : 'ltr'}`}
       role="grid"
       style={{
         '--cl-color-primary': colorPrimary,
@@ -199,7 +205,7 @@ Calendar.propTypes = {
   slideAnimationDuration: PropTypes.string,
   minimumDate: PropTypes.shape(DAY_SHAPE),
   maximumDate: PropTypes.shape(DAY_SHAPE),
-  locale: PropTypes.oneOf(['en', 'fa']),
+  locale: PropTypes.oneOfType([PropTypes.oneOf(['en', 'fa']), LOCALE_SHAPE]),
 };
 
 export { Calendar };

--- a/src/DatePicker.css
+++ b/src/DatePicker.css
@@ -13,7 +13,7 @@
   font-size: 12px;
 }
 
-.DatePicker__input.-fa {
+.DatePicker__input.-rtl {
   direction: rtl;
 }
 
@@ -51,7 +51,7 @@
 }
 
 .Calendar,
-.Calendar.-fa * {
+.Calendar.-rtl * {
   direction: rtl;
 }
 
@@ -119,14 +119,14 @@
 .Calendar__monthArrowWrapper.-left {
   transform: rotate(90deg);
 }
-.Calendar.-fa .Calendar__monthArrowWrapper.-left {
+.Calendar.-rtl .Calendar__monthArrowWrapper.-left {
   transform: rotate(-90deg);
 }
 
 .Calendar__monthArrowWrapper.-right {
   transform: rotate(-90deg);
 }
-.Calendar.-fa .Calendar__monthArrowWrapper.-right {
+.Calendar.-rtl .Calendar__monthArrowWrapper.-right {
   transform: rotate(90deg);
 }
 
@@ -172,7 +172,7 @@
   transform: translateX(50%);
 }
 
-.Calendar.-fa .Calendar__monthYear.-hiddenNext {
+.Calendar.-rtl .Calendar__monthYear.-hiddenNext {
   transform: translateX(-150%);
 }
 
@@ -181,7 +181,7 @@
   transform: translateX(-150%);
 }
 
-.Calendar.-fa .Calendar__monthYear.-hiddenPrevious {
+.Calendar.-rtl .Calendar__monthYear.-hiddenPrevious {
   transform: translateX(50%);
 }
 
@@ -212,6 +212,7 @@
 .Calendar__monthYear:not(.-shown) > *,
 .Calendar__monthYear > *.-hidden {
   cursor: default;
+  pointer-events: none;
 }
 
 .Calendar__monthText {
@@ -230,14 +231,14 @@
 .Calendar__monthText:hover {
   transform: translateX(-0.2em) scale(0.95);
 }
-.Calendar.-fa .Calendar__monthText:hover {
+.Calendar.-rtl .Calendar__monthText:hover {
   transform: translateX(0.2em) scale(0.95);
 }
 
 .Calendar__yearText:hover {
   transform: translateX(0.2em) scale(0.95);
 }
-.Calendar.-fa .Calendar__yearText:hover {
+.Calendar.-rtl .Calendar__yearText:hover {
   transform: translateX(-0.2em) scale(0.95);
 }
 
@@ -246,7 +247,7 @@
   opacity: 0;
 }
 
-.Calendar.-fa .Calendar__monthYear .Calendar__yearText.-hidden {
+.Calendar.-rtl .Calendar__monthYear .Calendar__yearText.-hidden {
   transform: translateX(-50%);
 }
 
@@ -255,7 +256,7 @@
   opacity: 0;
 }
 
-.Calendar.-fa .Calendar__monthYear .Calendar__monthText.-hidden {
+.Calendar.-rtl .Calendar__monthYear .Calendar__monthText.-hidden {
   transform: translateX(50%);
 }
 
@@ -459,7 +460,7 @@
   transform: translateX(-90%);
 }
 
-.Calendar.-fa .Calendar__section.-hiddenPrevious {
+.Calendar.-rtl .Calendar__section.-hiddenPrevious {
   transform: translateX(90%);
 }
 
@@ -468,7 +469,7 @@
   transform: translateX(90%);
 }
 
-.Calendar.-fa .Calendar__section.-hiddenNext {
+.Calendar.-rtl .Calendar__section.-hiddenNext {
   transform: translateX(-90%);
 }
 
@@ -508,12 +509,12 @@
   outline-offset: 2px;
 }
 
-.Calendar__day.-en {
+.Calendar__day.-ltr {
   min-height: 2.6em;
   font-size: 1.45em;
 }
 
-.Calendar__day.-fa {
+.Calendar__day.-rtl {
   font-size: 1.55em;
   height: 2.45em;
 }
@@ -532,13 +533,13 @@
   color: #fff;
 }
 
-.Calendar__day.-en.-selectedStart {
+.Calendar__day.-ltr.-selectedStart {
   border-radius: 0;
   border-top-left-radius: 100em;
   border-bottom-left-radius: 100em;
 }
 
-.Calendar__day.-fa.-selectedStart {
+.Calendar__day.-rtl.-selectedStart {
   border-radius: 0;
   border-top-right-radius: 100em;
   border-bottom-right-radius: 100em;
@@ -550,12 +551,12 @@
   border-radius: 0;
 }
 
-.Calendar__day.-en.-selectedEnd {
+.Calendar__day.-ltr.-selectedEnd {
   border-top-right-radius: 100em;
   border-bottom-right-radius: 100em;
 }
 
-.Calendar__day.-fa.-selectedEnd {
+.Calendar__day.-rtl.-selectedEnd {
   border-top-left-radius: 100em;
   border-bottom-left-radius: 100em;
 }

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Calendar } from './Calendar';
 import DatePickerInput from './DatePickerInput';
 import { getValueType } from './shared/generalUtils';
-import { TYPE_SINGLE_DATE, TYPE_MUTLI_DATE, TYPE_RANGE } from './shared/constants';
+import { TYPE_SINGLE_DATE, TYPE_MUTLI_DATE, TYPE_RANGE, LOCALE_SHAPE } from './shared/constants';
 
 const DatePicker = ({
   value,
@@ -179,7 +179,7 @@ DatePicker.defaultProps = {
 
 DatePicker.propTypes = {
   wrapperClassName: PropTypes.string,
-  locale: PropTypes.oneOf(['en', 'fa']),
+  locale: PropTypes.oneOfType([PropTypes.oneOf(['en', 'fa']), LOCALE_SHAPE]),
 };
 
 export default DatePicker;

--- a/src/DatePickerInput.js
+++ b/src/DatePickerInput.js
@@ -14,6 +14,7 @@ const DatePickerInput = React.forwardRef(
       yearLetterSkip,
       digitSeparator,
       defaultPlaceholder,
+      isRtl,
     } = useLocaleLanguage(locale);
 
     const getSingleDayValue = () => {
@@ -58,7 +59,6 @@ const DatePickerInput = React.forwardRef(
     };
 
     const placeholderValue = inputPlaceholder || defaultPlaceholder;
-
     const render = () => {
       return (
         renderInput({ ref }) || (
@@ -68,7 +68,7 @@ const DatePickerInput = React.forwardRef(
             ref={ref}
             value={getValue()}
             placeholder={placeholderValue}
-            className={`DatePicker__input -${locale} ${inputClassName}`}
+            className={`DatePicker__input -${isRtl ? 'rtl' : 'ltr'} ${inputClassName}`}
             aria-label={placeholderValue}
           />
         )

--- a/src/components/DaysList.js
+++ b/src/components/DaysList.js
@@ -195,7 +195,7 @@ const DaysList = ({
       <div
         tabIndex={shouldEnableKeyboardNavigation ? '0' : '-1'}
         key={id}
-        className={`Calendar__day -${locale} ${additionalClass}`}
+        className={`Calendar__day -${isRtl ? 'rtl' : 'ltr'} ${additionalClass}`}
         onClick={() => {
           handleDayPress({ ...dayItem, isDisabled });
         }}

--- a/src/components/YearSelector.js
+++ b/src/components/YearSelector.js
@@ -31,6 +31,11 @@ const YearSelector = ({
     const activeSelectorYear = wrapperElement.current.querySelector(
       '.Calendar__yearSelectorItem.-active',
     );
+    if (!activeSelectorYear) {
+      throw new RangeError(
+        `Provided value for year is out of selectable year range. You're probably using a wrong locale prop value or your provided value's locale is different from the date picker locale. Try changing the 'locale' prop or the value you've provided.`,
+      );
+    }
     wrapperElement.current.classList[classToggleMethod]('-faded');
     yearListElement.current.scrollTop =
       activeSelectorYear.offsetTop - activeSelectorYear.offsetHeight * 5;

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -65,3 +65,25 @@ export const MAXIMUM_SELECTABLE_YEAR_SUM = 50;
 export const TYPE_SINGLE_DATE = 'SINGLE_DATE';
 export const TYPE_RANGE = 'RANGE';
 export const TYPE_MUTLI_DATE = 'MUTLI_DATE';
+
+export const LOCALE_SHAPE = PropTypes.shape({
+  months: PropTypes.arrayOf(PropTypes.string),
+  weekDays: PropTypes.arrayOf(PropTypes.string),
+  weekStartingIndex: PropTypes.number,
+  getToday: PropTypes.func,
+  toNativeDate: PropTypes.func,
+  getMonthLength: PropTypes.func,
+  transformDigit: PropTypes.func,
+  nextMonth: PropTypes.string,
+  previousMonth: PropTypes.string,
+  openMonthSelector: PropTypes.string,
+  openYearSelector: PropTypes.string,
+  closeMonthSelector: PropTypes.string,
+  closeYearSelector: PropTypes.string,
+  from: PropTypes.string,
+  to: PropTypes.string,
+  defaultPlaceholder: PropTypes.string,
+  digitSeparator: PropTypes.string,
+  yearLetterSkip: PropTypes.number,
+  isRtl: PropTypes.bool,
+});

--- a/src/shared/localeLanguages.js
+++ b/src/shared/localeLanguages.js
@@ -1,14 +1,31 @@
+import jalaali from 'jalaali-js';
+
 import {
   GREGORIAN_MONTHS,
   PERSIAN_MONTHS,
   GREGORIAN_WEEK_DAYS,
   PERSIAN_WEEK_DAYS,
+  PERSIAN_NUMBERS,
 } from './constants';
+import { toExtendedDay } from './generalUtils';
 
 const localeLanguages = {
   en: {
     months: GREGORIAN_MONTHS,
     weekDays: GREGORIAN_WEEK_DAYS,
+    weekStartingIndex: 0,
+    getToday(gregorainTodayObject) {
+      return gregorainTodayObject;
+    },
+    toNativeDate(date) {
+      return new Date(date.year, date.month - 1, date.day);
+    },
+    getMonthLength(date) {
+      return new Date(date.year, date.month, 0).getDate();
+    },
+    transformDigit(digit) {
+      return digit;
+    },
     nextMonth: 'Next Month',
     previousMonth: 'Previous Month',
     openMonthSelector: 'Open Month Selector',
@@ -25,6 +42,25 @@ const localeLanguages = {
   fa: {
     months: PERSIAN_MONTHS,
     weekDays: PERSIAN_WEEK_DAYS,
+    weekStartingIndex: 1,
+    getToday({ year, month, day }) {
+      const { jy, jm, jd } = jalaali.toJalaali(year, month, day);
+      return { year: jy, month: jm, day: jd };
+    },
+    toNativeDate(date) {
+      const gregorian = jalaali.toGregorian(...toExtendedDay(date));
+      return new Date(gregorian.gy, gregorian.gm - 1, gregorian.gd);
+    },
+    getMonthLength(date) {
+      return jalaali.jalaaliMonthLength(date.year, date.month);
+    },
+    transformDigit(digit) {
+      return digit
+        .toString()
+        .split('')
+        .map(letter => PERSIAN_NUMBERS[Number(letter)])
+        .join('');
+    },
     nextMonth: 'ماه بعد',
     previousMonth: 'ماه قبل',
     openMonthSelector: 'نمایش انتخابگر ماه',
@@ -40,6 +76,10 @@ const localeLanguages = {
   },
 };
 
-const getLanguageText = locale => localeLanguages[locale];
+const getLocaleDetails = locale => {
+  if (typeof locale === 'string') return localeLanguages[locale];
+  return locale;
+};
 
-export default getLanguageText;
+export { localeLanguages };
+export default getLocaleDetails;

--- a/test/datepicker-visibility.test.js
+++ b/test/datepicker-visibility.test.js
@@ -11,6 +11,15 @@ const renderOpenDatePicker = (renderProps = {}) => {
 };
 
 describe('DatePicker Visibility', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {}); // hide errors on console for toThrow passing tests
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.error.mockRestore();
+  });
+
   test('toggles correctly on input focus/blur', () => {
     const { queryByTestId, getByTestId, getByText } = render(
       <div>
@@ -178,5 +187,21 @@ describe('DatePicker Visibility', () => {
     expect(container.firstChild).toHaveClass('-noFocusOutline');
     fireEvent.keyUp(container.firstChild, { key: 'Tab' });
     expect(container.firstChild).not.toHaveClass('-noFocusOutline');
+  });
+
+  test('throws an error when year is out of valid bounds', () => {
+    expect(() => {
+      renderOpenDatePicker({
+        value: { year: 1999, month: 1, day: 1 },
+        selectorStartingYear: 2000,
+      });
+    }).toThrow(RangeError);
+
+    expect(() => {
+      renderOpenDatePicker({
+        value: { year: 2051, month: 1, day: 1 },
+        selectorEndingYear: 2050,
+      });
+    }).toThrow(RangeError);
   });
 });

--- a/test/datepicker-visibility.test.js
+++ b/test/datepicker-visibility.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 import DatePicker, { Calendar } from '../src';
+import { localeLanguages } from '../src/shared/localeLanguages';
 
 const renderOpenDatePicker = (renderProps = {}) => {
   const { getByTestId, ...otherSelectors } = render(<DatePicker {...renderProps} />);
@@ -11,15 +12,6 @@ const renderOpenDatePicker = (renderProps = {}) => {
 };
 
 describe('DatePicker Visibility', () => {
-  beforeEach(() => {
-    jest.spyOn(console, 'error').mockImplementation(() => {}); // hide errors on console for toThrow passing tests
-  });
-
-  afterEach(() => {
-    // eslint-disable-next-line no-console
-    console.error.mockRestore();
-  });
-
   test('toggles correctly on input focus/blur', () => {
     const { queryByTestId, getByTestId, getByText } = render(
       <div>
@@ -189,19 +181,19 @@ describe('DatePicker Visibility', () => {
     expect(container.firstChild).not.toHaveClass('-noFocusOutline');
   });
 
-  test('throws an error when year is out of valid bounds', () => {
-    expect(() => {
-      renderOpenDatePicker({
-        value: { year: 1999, month: 1, day: 1 },
-        selectorStartingYear: 2000,
-      });
-    }).toThrow(RangeError);
+  test('renders the datepicker with custom locale prop', () => {
+    // ltr language
+    expect(
+      render(<DatePicker value={null} onChange={() => {}} locale="en" />).container,
+    ).toStrictEqual(
+      render(<DatePicker value={null} onChange={() => {}} locale={localeLanguages.en} />).container,
+    );
 
-    expect(() => {
-      renderOpenDatePicker({
-        value: { year: 2051, month: 1, day: 1 },
-        selectorEndingYear: 2050,
-      });
-    }).toThrow(RangeError);
+    // rtl language
+    expect(
+      render(<DatePicker value={null} onChange={() => {}} locale="fa" />).container,
+    ).toStrictEqual(
+      render(<DatePicker value={null} onChange={() => {}} locale={localeLanguages.fa} />).container,
+    );
   });
 });

--- a/test/year-selection.test.js
+++ b/test/year-selection.test.js
@@ -28,6 +28,15 @@ const renderYearSelector = (shouldOpenSelector = true, props = { value: null }) 
 };
 
 describe('Year Selection', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {}); // hide errors on console for toThrow passing tests
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.error.mockRestore();
+  });
+
   test('toggles on year click', () => {
     const { yearSelector, yearButton } = renderYearSelector(false);
 
@@ -123,5 +132,21 @@ describe('Year Selection', () => {
 
     fireEvent.keyDown(yearSelectorWrapper, { key: 'ArrowRight' });
     expect(document.activeElement).toBe(getByText('2018'));
+  });
+
+  test('throws an error when year is out of valid bounds', () => {
+    expect(() => {
+      renderYearSelector(false, {
+        value: { year: 1999, month: 1, day: 1 },
+        selectorStartingYear: 2000,
+      });
+    }).toThrow(RangeError);
+
+    expect(() => {
+      renderYearSelector(false, {
+        value: { year: 2051, month: 1, day: 1 },
+        selectorEndingYear: 2050,
+      });
+    }).toThrow(RangeError);
   });
 });

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
     title: `React Modern Calendar Date Picker`,
     description: `A modern, beautiful, customizable date picker for React`,
     author: `Kiarash Zarinmehr`,
-    version: `2.0.0`,
+    version: `2.1.0`,
   },
   pathPrefix: `/react-modern-calendar-datepicker`,
   plugins: [

--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
-    "react-modern-calendar-datepicker": "^2.0.0",
+    "react-modern-calendar-datepicker": "^2.1.0",
     "shortid": "^2.2.14"
   },
   "devDependencies": {

--- a/website/src/pages/docs/different-locales.js
+++ b/website/src/pages/docs/different-locales.js
@@ -4,6 +4,57 @@ import DatePicker, { Calendar } from 'react-modern-calendar-datepicker';
 import Docs from '../../containers/docs';
 import { Code } from '../../components';
 
+const myCustomLocale = {
+  months: [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ],
+  weekDays: [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ],
+  weekStartingIndex: 0,
+  getToday(gregorainTodayObject) {
+    return gregorainTodayObject;
+  },
+  toNativeDate(date) {
+    return new Date(date.year, date.month - 1, date.day);
+  },
+  getMonthLength(date) {
+    return new Date(date.year, date.month, 0).getDate();
+  },
+  transformDigit(digit) {
+    return digit;
+  },
+  nextMonth: 'Next Month',
+  previousMonth: 'Previous Month',
+  openMonthSelector: 'Open Month Selector',
+  openYearSelector: 'Open Year Selector',
+  closeMonthSelector: 'Close Month Selector',
+  closeYearSelector: 'Close Year Selector',
+  from: 'from',
+  to: 'to',
+  defaultPlaceholder: 'Select...',
+  digitSeparator: ',',
+  yearLetterSkip: 0,
+  isRtl: false,
+};
+
 const DefaultValues = () => {
   const [datePicker1Value, setDatePicker1Value] = useState(null);
   const [datePicker2Value, setDatePicker2Value] = useState(null);
@@ -11,11 +62,18 @@ const DefaultValues = () => {
   return (
     <Docs title="Different Locales">
       <p>
-        Turning this date picker into another locale date picker is as easy as changing
-        the <code className="custom-code">locale</code> prop. For
-        other features like minimum and maximum dates, just use them as you would normally use:
+        Turning this date picker into another locale date picker is as easy as
+        changing the <code className="custom-code">locale</code> prop. For other
+        features like minimum and maximum dates, just use them as you would
+        normally use:
       </p>
-      <h2 className="Docs__titleSecondary">Persian Locale</h2>
+      <h2 className="Docs__titleSecondary">Using Predefined Locales</h2>
+      <p>
+        For now, there are two predefined locales;{' '}
+        <code className="custom-code">en</code> and{' '}
+        <code className="custom-code">fa</code>. You can use them by passing
+        them to <code className="custom-code">locale</code> prop as a string.
+      </p>
       <div className="Docs__sampleContainer">
         <Code language="javascript">
           {`
@@ -30,7 +88,7 @@ const App = () => {
       value={selectedDay}
       onChange={setSelectedDay}
       shouldHighlightWeekends
-      locale="fa // add this
+      locale="fa" // add this
     />
   );
 };
@@ -48,10 +106,9 @@ export default App;
           shouldHighlightWeekends
         />
       </div>
-
       <div className="Docs__sampleContainer">
-              <Code language="javascript">
-                {`
+        <Code language="javascript">
+          {`
 import React, { useState } from "react";
 import "react-modern-calendar-datepicker/lib/DatePicker.css";
 import { Calendar } from "react-modern-calendar-datepicker";
@@ -71,15 +128,128 @@ const App = () => {
 export default App;
 
                 `}
-              </Code>
-              <Calendar
-                calendarClassName="fontWrapper -persian responsive-calendar"
-                value={datePicker2Value}
-                onChange={setDatePicker2Value}
-                locale="fa"
-                shouldHighlightWeekends
-              />
-            </div>
+        </Code>
+        <Calendar
+          calendarClassName="fontWrapper -persian responsive-calendar"
+          value={datePicker2Value}
+          onChange={setDatePicker2Value}
+          locale="fa"
+          shouldHighlightWeekends
+        />
+      </div>
+      <h2 className="Docs__titleSecondary">Using Custom Locales</h2>
+      <p>
+        If your locale is missing in predefined locales, you can add your own
+        custom locale by passing a locale object to{' '}
+        <code className="custom-code">locale</code> prop. This is an example of
+        default English picker&#39;s data:
+      </p>
+      <div className="Docs__sampleContainer">
+        <Code language="javascript">
+          {`
+import React, { useState } from "react";
+import "react-modern-calendar-datepicker/lib/DatePicker.css";
+import { Calendar } from "react-modern-calendar-datepicker";
+
+const myCustomLocale = {
+  // months list by order
+  months: [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+  ],
+
+  // week days by order
+  weekDays: [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ],
+
+  // just play around with this number between 0 and 6
+  weekStartingIndex: 0,
+
+  // return a { year: number, month: number, day: number } object
+  getToday(gregorainTodayObject) {
+    return gregorainTodayObject;
+  },
+
+  // return a native JavaScript date here
+  toNativeDate(date) {
+    return new Date(date.year, date.month - 1, date.day);
+  },
+
+  // return a number for date's month length
+  getMonthLength(date) {
+    return new Date(date.year, date.month, 0).getDate();
+  },
+
+  // return a transformed digit to your locale
+  transformDigit(digit) {
+    return digit;
+  },
+
+  // texts in the date picker
+  nextMonth: 'Next Month',
+  previousMonth: 'Previous Month',
+  openMonthSelector: 'Open Month Selector',
+  openYearSelector: 'Open Year Selector',
+  closeMonthSelector: 'Close Month Selector',
+  closeYearSelector: 'Close Year Selector',
+  defaultPlaceholder: 'Select...',
+
+  // for input range value
+  from: 'from',
+  to: 'to',
+
+
+  // used for input value when multi dates are selected
+  digitSeparator: ',',
+
+  // if your provide -2 for example, year will be 2 digited
+  yearLetterSkip: 0,
+
+  // is your language rtl or ltr?
+  isRtl: false,
+}
+
+const App = () => {
+  const [selectedDay, setSelectedDay] = useState(null);
+  return (
+    <Calendar
+      value={selectedDay}
+      onChange={setSelectedDay}
+      locale={myCustomLocale} // custom locale object
+      shouldHighlightWeekends
+    />
+  );
+};
+
+export default App;
+
+                      `}
+        </Code>
+        <Calendar
+          calendarClassName="responsive-calendar"
+          value={datePicker2Value}
+          onChange={setDatePicker2Value}
+          locale={myCustomLocale}
+          shouldHighlightWeekends
+        />
+      </div>
     </Docs>
   );
 };

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8500,10 +8500,10 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-modern-calendar-datepicker@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-modern-calendar-datepicker/-/react-modern-calendar-datepicker-2.0.0.tgz#45bc4a3744e377f69a7d2ed518db892f5e5d842a"
-  integrity sha512-sgNKGIH3Ie0tQt9u+ON/m/ziJznkpquPWPOgRTr3PB62W4LzwonsigQ/GJgw8SQ1ATHqXc9hpcNuwuKfJUmH5Q==
+react-modern-calendar-datepicker@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-modern-calendar-datepicker/-/react-modern-calendar-datepicker-2.1.0.tgz#cbb867462a00aeff81830678ae6158b67125732a"
+  integrity sha512-0OqKW1ApoiKRXr0h1JTyVEvfvCcHH52MWNui0O12BiO6Ogxjba71uE1OwOK4lTb+BS1LqJ0C3Ngx33lrAgidNw==
   dependencies:
     jalaali-js "^1.1.0"
     prop-types "^15.7.2"


### PR DESCRIPTION
- Support for custom locale prop related to #99 
- Fix an issue related to weird behavior of year or month selector top text related to #97 
- Throw a helpful error when the provided year for value is out of the valid year range related to #96. The date picker will still crash(it shouldn't fail silently), but a helpful error will be thrown.