### PR TITLE
v3.0.3

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export interface CalendarProps<TValue extends Value> {
   onDisabledDayError?(value: Day): void;
   selectorStartingYear?: number;
   selectorEndingYear?: number;
-  locale?: string;
+  locale?: string | Locale;
   minimumDate?: Day;
   maximumDate?: Day;
   disabledDays?: Day[];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modern-calendar-datepicker",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A modern, beautiful, customizable date picker for React",
   "main": "lib/index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modern-calendar-datepicker",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A modern, beautiful, customizable date picker for React",
   "main": "lib/index.js",
   "types": "index.d.ts",

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -79,7 +79,7 @@ const Calendar = ({
     : getComputedActiveDate();
 
   const weekdays = weekDaysList.map(weekDay => (
-    <abbr key={weekDay.name} title={weekDay} className="Calendar__weekDay">
+    <abbr key={weekDay.name} title={weekDay.name} className="Calendar__weekDay">
       {weekDay.short}
     </abbr>
   ));

--- a/src/DatePicker.css
+++ b/src/DatePicker.css
@@ -89,7 +89,7 @@
   outline: none !important;
 }
 
-.Calendar button {
+.Calendar *:not(.Calendar__footer) button {
   font-family: inherit;
   background: transparent;
   cursor: pointer;

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
     title: `React Modern Calendar Date Picker`,
     description: `A modern, beautiful, customizable date picker for React`,
     author: `Kiarash Zarinmehr`,
-    version: `3.0.1`,
+    version: `3.0.3`,
   },
   pathPrefix: `/react-modern-calendar-datepicker`,
   plugins: [

--- a/website/src/pages/docs/customization.js
+++ b/website/src/pages/docs/customization.js
@@ -152,7 +152,7 @@ export default App;
         </Code>
 
         <DatePicker
-          wrapperClassName="fontWrapper -aboveAll"
+          wrapperClassName="fontWrapper"
           calendarClassName="fontWrapper"
           value={datePicker2Value}
           onChange={setDatePicker2Value}


### PR DESCRIPTION
This version includes minor fixes:

- Fix TypeScript type for `locale` prop which couldn't take the `Locale` shaped objects as value. Related to #130 
- Fix title for abbr tag on weekdays. Related to #124 
- Removed button styles for any button in the calendar to fix custom buttons' styles provided in `renderFooter`. Related to #128 