### PR TITLE
fix: typescript error regarding null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ export type Day = {
   day: number;
 };
 
-export type DayValue = Day | null;
+export type DayValue = Day | undefined;
 
 export type DayRange = { from: DayValue; to: DayValue };
 
@@ -66,7 +66,7 @@ type WeekDay = {
   name: string;
   short: string;
   isWeekend?: boolean;
-}
+};
 
 export type Utils = {
   monthsList: string[];

--- a/website/src/pages/docs/typescript.js
+++ b/website/src/pages/docs/typescript.js
@@ -24,7 +24,7 @@ const Installation = () => {
       </p>
 
       <p className="Docs__paragraph">
-         You can use <code className="custom-code">Day</code> and <code className="custom-code">DayRange</code> types that has been exported by this package to define generic type variable.
+        You can use <code className="custom-code">Day</code> and <code className="custom-code">DayRange</code> types that has been exported by this package to define generic type variable.
       </p>
 
       <Code language="javascript">{`
@@ -32,10 +32,10 @@ import React from 'react'
 import DatePicker, { DayValue, DayRange, Day } from 'react-modern-calendar-datepicker'
 
 function App() {
-  const [day, setDay] = React.useState<DayValue>(null);
+  const [day, setDay] = React.useState<DayValue>(undefined);
   const [dayRange, setDayRange] = React.useState<DayRange>({
-    from: null,
-    to: null
+    from: undefined,
+    to: undefined
   });
   const [days, setDays] = React.useState<Day[]>([]);
 


### PR DESCRIPTION
The value for `DayValue` should be `Date | undefined` not null. 
If you let it be null you will get the following error as I do. 

```
TypeScript error in /Users/brandonroberts/code/weight/src/App.tsx(39,9):
No overload matches this call.
  Overload 1 of 3, '(props: Optional<DatePickerProps<Day>, "value">): ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)>', gave the following error.
    Type 'DayValue' is not assignable to type 'Day | undefined'.
      Type 'null' is not assignable to type 'Day | undefined'.  TS2769

    37 | 
    38 |       <DatePicker
  > 39 |         value={day}
       |         ^
    40 |         onChange={setDay}
    41 |         inputPlaceholder="Select a day range"
    42 |         shouldHighlightWeekends
```

For more info about this issue https://github.com/Microsoft/TypeScript/issues/26214
```
null is a different type and value from boolean and undefined. undefined === null would also result to false. So if you want this to run without an error, you have two options:

Assign undefined, not null, because the type says it accepts either boolean or undefined.
Change the type to include null, e.g. boolean | undefined | null (or prop?: boolean | null).
```