### PR TITLE
v3.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modern-calendar-datepicker",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11326,7 +11326,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -12197,6 +12198,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -12982,7 +12984,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -14356,6 +14359,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -14553,7 +14557,8 @@
     "react-is": {
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
+      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
+      "dev": true
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     }
   ],
   "dependencies": {
-    "jalaali-js": "^1.1.0",
-    "prop-types": "^15.7.2"
+    "jalaali-js": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modern-calendar-datepicker",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "A modern, beautiful, customizable date picker for React",
   "main": "lib/index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modern-calendar-datepicker",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "A modern, beautiful, customizable date picker for React",
   "main": "lib/index.js",
   "types": "index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ const config = {
     format: 'cjs',
     exports: 'named',
   },
-  external: ['react', 'react-dom', 'prop-types'],
+  external: ['react', 'react-dom'],
   plugins: [
     resolve(),
     babel({

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,14 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
-import PropTypes from 'prop-types';
 
 import { getDateAccordingToMonth, shallowClone, getValueType } from './shared/generalUtils';
-import {
-  DAY_SHAPE,
-  TYPE_SINGLE_DATE,
-  TYPE_RANGE,
-  TYPE_MUTLI_DATE,
-  LOCALE_SHAPE,
-} from './shared/constants';
+import { TYPE_SINGLE_DATE, TYPE_RANGE, TYPE_MUTLI_DATE } from './shared/constants';
 import { useLocaleUtils, useLocaleLanguage } from './shared/hooks';
 
 import { Header, MonthSelector, YearSelector, DaysList } from './components';
@@ -197,25 +190,6 @@ Calendar.defaultProps = {
   value: null,
   renderFooter: () => null,
   customDaysClassName: [],
-};
-
-Calendar.propTypes = {
-  value: PropTypes.oneOfType([
-    PropTypes.shape(DAY_SHAPE),
-    PropTypes.shape({ from: PropTypes.shape(DAY_SHAPE), to: PropTypes.shape(DAY_SHAPE) }),
-    PropTypes.arrayOf(PropTypes.shape(DAY_SHAPE)),
-  ]),
-  calendarClassName: PropTypes.string,
-  colorPrimary: PropTypes.string,
-  colorPrimaryLight: PropTypes.string,
-  slideAnimationDuration: PropTypes.string,
-  minimumDate: PropTypes.shape(DAY_SHAPE),
-  maximumDate: PropTypes.shape(DAY_SHAPE),
-  locale: PropTypes.oneOfType([PropTypes.oneOf(['en', 'fa']), LOCALE_SHAPE]),
-  renderFooter: PropTypes.func,
-  customDaysClassName: PropTypes.arrayOf(
-    PropTypes.shape({ ...DAY_SHAPE, className: PropTypes.string }),
-  ),
 };
 
 export { Calendar };

--- a/src/DatePicker.css
+++ b/src/DatePicker.css
@@ -101,7 +101,7 @@
   outline: none !important;
 }
 
-.Calendar >:not(.Calendar__footer) button {
+.Calendar > :not(.Calendar__footer) button {
   font-family: inherit;
   background: transparent;
   cursor: pointer;

--- a/src/DatePicker.css
+++ b/src/DatePicker.css
@@ -101,7 +101,7 @@
   outline: none !important;
 }
 
-.Calendar *:not(.Calendar__footer) button {
+.Calendar >:not(.Calendar__footer) button {
   font-family: inherit;
   background: transparent;
   cursor: pointer;

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -1,10 +1,9 @@
 import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
-import PropTypes from 'prop-types';
 
 import { Calendar } from './Calendar';
 import DatePickerInput from './DatePickerInput';
 import { getValueType } from './shared/generalUtils';
-import { TYPE_SINGLE_DATE, TYPE_MUTLI_DATE, TYPE_RANGE, LOCALE_SHAPE } from './shared/constants';
+import { TYPE_SINGLE_DATE, TYPE_MUTLI_DATE, TYPE_RANGE } from './shared/constants';
 
 const DatePicker = ({
   value,
@@ -199,12 +198,6 @@ DatePicker.defaultProps = {
   wrapperClassName: '',
   locale: 'en',
   calendarPopperPosition: 'auto',
-};
-
-DatePicker.propTypes = {
-  wrapperClassName: PropTypes.string,
-  locale: PropTypes.oneOfType([PropTypes.oneOf(['en', 'fa']), LOCALE_SHAPE]),
-  calendarPopperPosition: PropTypes.oneOf(['auto', 'top', 'bottom']),
 };
 
 export default DatePicker;

--- a/src/DatePickerInput.js
+++ b/src/DatePickerInput.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { useLocaleUtils, useLocaleLanguage } from './shared/hooks';
 import { putZero, getValueType } from './shared/generalUtils';
@@ -89,14 +88,6 @@ DatePickerInput.defaultProps = {
   inputPlaceholder: '',
   inputClassName: '',
   inputName: '',
-};
-
-DatePickerInput.propTypes = {
-  formatInputText: PropTypes.func,
-  inputPlaceholder: PropTypes.string,
-  inputClassName: PropTypes.string,
-  inputName: PropTypes.string,
-  renderInput: PropTypes.func,
 };
 
 export default DatePickerInput;

--- a/src/components/DaysList.js
+++ b/src/components/DaysList.js
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect } from 'react';
-import PropTypes from 'prop-types';
 
 import { getSlideDate, handleSlideAnimationEnd, animateContent } from '../shared/sliderHelpers';
 import {
@@ -8,7 +7,7 @@ import {
   createUniqueRange,
   getValueType,
 } from '../shared/generalUtils';
-import { DAY_SHAPE, TYPE_SINGLE_DATE, TYPE_RANGE, TYPE_MUTLI_DATE } from '../shared/constants';
+import { TYPE_SINGLE_DATE, TYPE_RANGE, TYPE_MUTLI_DATE } from '../shared/constants';
 import handleKeyboardNavigation from '../shared/keyboardNavigation';
 import { useLocaleUtils, useLocaleLanguage } from '../shared/hooks';
 
@@ -275,19 +274,6 @@ const DaysList = ({
       </div>
     </div>
   );
-};
-
-DaysList.propTypes = {
-  onChange: PropTypes.func,
-  onDisabledDayError: PropTypes.func,
-  disabledDays: PropTypes.arrayOf(PropTypes.shape(DAY_SHAPE)),
-  calendarTodayClassName: PropTypes.string,
-  calendarSelectedDayClassName: PropTypes.string,
-  calendarRangeStartClassName: PropTypes.string,
-  calendarRangeBetweenClassName: PropTypes.string,
-  calendarRangeEndClassName: PropTypes.string,
-  shouldHighlightWeekends: PropTypes.bool,
-  isQuickSelectorOpen: PropTypes.bool.isRequired,
 };
 
 DaysList.defaultProps = {

--- a/src/components/YearSelector.js
+++ b/src/components/YearSelector.js
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect } from 'react';
-import PropTypes from 'prop-types';
 
 import { MINIMUM_SELECTABLE_YEAR_SUBTRACT, MAXIMUM_SELECTABLE_YEAR_SUM } from '../shared/constants';
 import handleKeyboardNavigation from '../shared/keyboardNavigation';
@@ -90,11 +89,6 @@ const YearSelector = ({
       </div>
     </div>
   );
-};
-
-YearSelector.propTypes = {
-  selectorStartingYear: PropTypes.number,
-  selectorEndingYear: PropTypes.number,
 };
 
 YearSelector.defaultProps = {

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -1,5 +1,3 @@
-import PropTypes from 'prop-types';
-
 export const PERSIAN_NUMBERS = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
 
 export const PERSIAN_MONTHS = [
@@ -97,12 +95,6 @@ export const GREGORIAN_WEEK_DAYS = [
   },
 ];
 
-export const DAY_SHAPE = {
-  year: PropTypes.number.isRequired,
-  month: PropTypes.number.isRequired,
-  day: PropTypes.number.isRequired,
-};
-
 export const MINIMUM_SELECTABLE_YEAR_SUBTRACT = 100;
 
 export const MAXIMUM_SELECTABLE_YEAR_SUM = 50;
@@ -110,31 +102,3 @@ export const MAXIMUM_SELECTABLE_YEAR_SUM = 50;
 export const TYPE_SINGLE_DATE = 'SINGLE_DATE';
 export const TYPE_RANGE = 'RANGE';
 export const TYPE_MUTLI_DATE = 'MUTLI_DATE';
-
-export const LOCALE_SHAPE = PropTypes.shape({
-  months: PropTypes.arrayOf(PropTypes.string),
-  weekDays: PropTypes.arrayOf(
-    PropTypes.shape({
-      name: PropTypes.string,
-      short: PropTypes.string,
-      isWeekend: PropTypes.bool,
-    }),
-  ),
-  weekStartingIndex: PropTypes.number,
-  getToday: PropTypes.func,
-  toNativeDate: PropTypes.func,
-  getMonthLength: PropTypes.func,
-  transformDigit: PropTypes.func,
-  nextMonth: PropTypes.string,
-  previousMonth: PropTypes.string,
-  openMonthSelector: PropTypes.string,
-  openYearSelector: PropTypes.string,
-  closeMonthSelector: PropTypes.string,
-  closeYearSelector: PropTypes.string,
-  from: PropTypes.string,
-  to: PropTypes.string,
-  defaultPlaceholder: PropTypes.string,
-  digitSeparator: PropTypes.string,
-  yearLetterSkip: PropTypes.number,
-  isRtl: PropTypes.bool,
-});

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
     title: `React Modern Calendar Date Picker`,
     description: `A modern, beautiful, customizable date picker for React`,
     author: `Kiarash Zarinmehr`,
-    version: `3.1.4`,
+    version: `3.1.5`,
   },
   pathPrefix: `/react-modern-calendar-datepicker`,
   plugins: [

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
     title: `React Modern Calendar Date Picker`,
     description: `A modern, beautiful, customizable date picker for React`,
     author: `Kiarash Zarinmehr`,
-    version: `3.1.5`,
+    version: `3.1.6`,
   },
   pathPrefix: `/react-modern-calendar-datepicker`,
   plugins: [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13227,12 +13227,11 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-modern-calendar-datepicker": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/react-modern-calendar-datepicker/-/react-modern-calendar-datepicker-3.1.5.tgz",
-      "integrity": "sha512-kB/SOFVijubViUM+SQUUBjy7jZ/9ArqljzPkQqlTMpGqlOc4n5Rn26CgztV1HVRu/yRza2/QrYgvgafOJSjzyA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/react-modern-calendar-datepicker/-/react-modern-calendar-datepicker-3.1.6.tgz",
+      "integrity": "sha512-lnMqEMj9Wn32/sm119tjCl5lOkq4u9vJE7wggi7hdXV4s8rPdKlH56FVVehlBi0dfYeWQVZ9npY384Zprjn4WA==",
       "requires": {
-        "jalaali-js": "^1.1.0",
-        "prop-types": "^15.7.2"
+        "jalaali-js": "^1.1.0"
       }
     },
     "react-reconciler": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13227,9 +13227,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-modern-calendar-datepicker": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-modern-calendar-datepicker/-/react-modern-calendar-datepicker-3.1.4.tgz",
-      "integrity": "sha512-IQFmCn02T3TyYev89iqXX0R374PxwNGAOZL6LZ+4wcVpBNZuo/fBBZLfxbWFFGWmwOfKbY3GsPp9Kc3hilgKHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/react-modern-calendar-datepicker/-/react-modern-calendar-datepicker-3.1.5.tgz",
+      "integrity": "sha512-kB/SOFVijubViUM+SQUUBjy7jZ/9ArqljzPkQqlTMpGqlOc4n5Rn26CgztV1HVRu/yRza2/QrYgvgafOJSjzyA==",
       "requires": {
         "jalaali-js": "^1.1.0",
         "prop-types": "^15.7.2"

--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
-    "react-modern-calendar-datepicker": "^3.1.4",
+    "react-modern-calendar-datepicker": "^3.1.5",
     "sharp": "^0.25.2",
     "shortid": "^2.2.14"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
-    "react-modern-calendar-datepicker": "^3.1.5",
+    "react-modern-calendar-datepicker": "^3.1.6",
     "sharp": "^0.25.2",
     "shortid": "^2.2.14"
   },

--- a/website/src/pages/docs/getting-started.js
+++ b/website/src/pages/docs/getting-started.js
@@ -9,7 +9,7 @@ const Installation = () => {
     <Docs title="Getting Started">
       <p className="Docs__paragraph">
         Welcome to docs! react-modern-calendar-datepicker (a quite long name!)
-        is a react date picker
+        is a React date picker
         package supporting other languages locales(for now there are <code className="custom-code">fa</code> and <code className="custom-code">en</code> locales).
         It&#39;s lightweight, and it&#39;s easy to use.
         Before using this package, please pay attention to these two important points:


### PR DESCRIPTION
This version includes the following changes:

- Fix an issue where styles for the calendar buttons were also applying to nested buttons in the calendar footer. Related to #165 
- Remove prop-types and rely on TypeScript types to reduce the bundle size