### PR TITLE
adds support of onDisplayedDateChangeEnd and onDisplayedDateChangeStart callbacks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,9 +14,20 @@ type Value = DayValue | Day[] | DayRange;
 
 type CustomDayClassNameItem = Day & { className: string };
 
+type Direction = "PREVIOUS" | "NEXT";
+
+export interface CalendarRef {
+  selectMonth(value: Direction | number): void;
+  selectYear(value: number): void;
+}
+
+type CalendarRefProp = React.RefAttributes<CalendarRef>;
+
 export interface CalendarProps<TValue extends Value> {
   value: TValue;
   onChange?(value: TValue): void;
+  onDisplayedDateChangeEnd?(valye: Day): void;
+  onDisplayedDateChangeStart?(info: { direction: Direction; currentDate: Day; nextDate: Day; }): void;
   onDisabledDayError?(value: Day): void;
   selectorStartingYear?: number;
   selectorEndingYear?: number;
@@ -38,9 +49,9 @@ export interface CalendarProps<TValue extends Value> {
   customDaysClassName?: CustomDayClassNameItem[];
 }
 
-export function Calendar(props: Optional<CalendarProps<DayValue>, 'value'>): React.ReactElement;
-export function Calendar(props: CalendarProps<Day[]>): React.ReactElement;
-export function Calendar(props: CalendarProps<DayRange>): React.ReactElement;
+export function Calendar(props: Optional<CalendarProps<DayValue>, 'value'> & CalendarRefProp): React.ReactElement;
+export function Calendar(props: CalendarProps<Day[]> & CalendarRefProp): React.ReactElement;
+export function Calendar(props: CalendarProps<DayRange> & CalendarRefProp): React.ReactElement;
 
 export type RenderInputProps = {
   ref: React.RefObject<HTMLElement>;
@@ -54,6 +65,7 @@ export interface DatePickerProps<TValue extends Value> extends CalendarProps<TVa
   inputPlaceholder?: string;
   formatInputText?: () => string;
   renderInput?: React.FC<RenderInputProps>;
+  calendarRef?: CalendarRefProp;
 }
 
 type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useImperativeHandle } from 'react';
 
 import { getDateAccordingToMonth, shallowClone, getValueType } from './shared/generalUtils';
 import { TYPE_SINGLE_DATE, TYPE_RANGE, TYPE_MUTLI_DATE } from './shared/constants';
@@ -6,178 +6,212 @@ import { useLocaleUtils, useLocaleLanguage } from './shared/hooks';
 
 import { Header, MonthSelector, YearSelector, DaysList } from './components';
 
-const Calendar = ({
-  value,
-  onChange,
-  onDisabledDayError,
-  calendarClassName,
-  calendarTodayClassName,
-  calendarSelectedDayClassName,
-  calendarRangeStartClassName,
-  calendarRangeBetweenClassName,
-  calendarRangeEndClassName,
-  disabledDays,
-  colorPrimary,
-  colorPrimaryLight,
-  slideAnimationDuration,
-  minimumDate,
-  maximumDate,
-  selectorStartingYear,
-  selectorEndingYear,
-  locale,
-  shouldHighlightWeekends,
-  renderFooter,
-  customDaysClassName,
-}) => {
-  const calendarElement = useRef(null);
-  const [mainState, setMainState] = useState({
-    activeDate: null,
-    monthChangeDirection: '',
-    isMonthSelectorOpen: false,
-    isYearSelectorOpen: false,
-  });
-
-  useEffect(() => {
-    const handleKeyUp = ({ key }) => {
-      /* istanbul ignore else */
-      if (key === 'Tab') calendarElement.current.classList.remove('-noFocusOutline');
-    };
-    calendarElement.current.addEventListener('keyup', handleKeyUp, false);
-    return () => {
-      calendarElement.current.removeEventListener('keyup', handleKeyUp, false);
-    };
-  });
-
-  const { getToday } = useLocaleUtils(locale);
-  const { weekDays: weekDaysList, isRtl } = useLocaleLanguage(locale);
-  const today = getToday();
-
-  const createStateToggler = property => () => {
-    setMainState({ ...mainState, [property]: !mainState[property] });
-  };
-
-  const toggleMonthSelector = createStateToggler('isMonthSelectorOpen');
-  const toggleYearSelector = createStateToggler('isYearSelectorOpen');
-
-  const getComputedActiveDate = () => {
-    const valueType = getValueType(value);
-    if (valueType === TYPE_MUTLI_DATE && value.length) return shallowClone(value[0]);
-    if (valueType === TYPE_SINGLE_DATE && value) return shallowClone(value);
-    if (valueType === TYPE_RANGE && value.from) return shallowClone(value.from);
-    return shallowClone(today);
-  };
-
-  const activeDate = mainState.activeDate
-    ? shallowClone(mainState.activeDate)
-    : getComputedActiveDate();
-
-  const weekdays = weekDaysList.map(weekDay => (
-    <abbr key={weekDay.name} title={weekDay.name} className="Calendar__weekDay">
-      {weekDay.short}
-    </abbr>
-  ));
-
-  const handleMonthChange = direction => {
-    setMainState({
-      ...mainState,
-      monthChangeDirection: direction,
-    });
-  };
-
-  const updateDate = () => {
-    setMainState({
-      ...mainState,
-      activeDate: getDateAccordingToMonth(activeDate, mainState.monthChangeDirection),
+const Calendar = React.forwardRef(
+  (
+    {
+      value,
+      onChange,
+      onDisplayedDateChangeEnd,
+      onDisplayedDateChangeStart,
+      onDisabledDayError,
+      calendarClassName,
+      calendarTodayClassName,
+      calendarSelectedDayClassName,
+      calendarRangeStartClassName,
+      calendarRangeBetweenClassName,
+      calendarRangeEndClassName,
+      disabledDays,
+      colorPrimary,
+      colorPrimaryLight,
+      slideAnimationDuration,
+      minimumDate,
+      maximumDate,
+      selectorStartingYear,
+      selectorEndingYear,
+      locale,
+      shouldHighlightWeekends,
+      renderFooter,
+      customDaysClassName,
+    },
+    ref,
+  ) => {
+    const calendarElement = useRef(null);
+    const [mainState, setMainState] = useState({
+      activeDate: null,
       monthChangeDirection: '',
-    });
-  };
-
-  const selectMonth = newMonthNumber => {
-    setMainState({
-      ...mainState,
-      activeDate: { ...activeDate, month: newMonthNumber },
       isMonthSelectorOpen: false,
-    });
-  };
-
-  const selectYear = year => {
-    setMainState({
-      ...mainState,
-      activeDate: { ...activeDate, year },
       isYearSelectorOpen: false,
     });
-  };
 
-  return (
-    <div
-      className={`Calendar -noFocusOutline ${calendarClassName} -${isRtl ? 'rtl' : 'ltr'}`}
-      role="grid"
-      style={{
-        '--cl-color-primary': colorPrimary,
-        '--cl-color-primary-light': colorPrimaryLight,
-        '--animation-duration': slideAnimationDuration,
-      }}
-      ref={calendarElement}
-    >
-      <Header
-        maximumDate={maximumDate}
-        minimumDate={minimumDate}
-        activeDate={activeDate}
-        onMonthChange={handleMonthChange}
-        onMonthSelect={toggleMonthSelector}
-        onYearSelect={toggleYearSelector}
-        monthChangeDirection={mainState.monthChangeDirection}
-        isMonthSelectorOpen={mainState.isMonthSelectorOpen}
-        isYearSelectorOpen={mainState.isYearSelectorOpen}
-        locale={locale}
-      />
+    useEffect(() => {
+      const handleKeyUp = ({ key }) => {
+        /* istanbul ignore else */
+        if (key === 'Tab') calendarElement.current.classList.remove('-noFocusOutline');
+      };
+      calendarElement.current.addEventListener('keyup', handleKeyUp, false);
+      return () => {
+        calendarElement.current.removeEventListener('keyup', handleKeyUp, false);
+      };
+    });
 
-      <MonthSelector
-        isOpen={mainState.isMonthSelectorOpen}
-        activeDate={activeDate}
-        onMonthSelect={selectMonth}
-        maximumDate={maximumDate}
-        minimumDate={minimumDate}
-        locale={locale}
-      />
+    const { getToday } = useLocaleUtils(locale);
+    const { weekDays: weekDaysList, isRtl } = useLocaleLanguage(locale);
+    const today = getToday();
 
-      <YearSelector
-        isOpen={mainState.isYearSelectorOpen}
-        activeDate={activeDate}
-        onYearSelect={selectYear}
-        selectorStartingYear={selectorStartingYear}
-        selectorEndingYear={selectorEndingYear}
-        maximumDate={maximumDate}
-        minimumDate={minimumDate}
-        locale={locale}
-      />
+    const createStateToggler = property => () => {
+      setMainState({ ...mainState, [property]: !mainState[property] });
+    };
 
-      <div className="Calendar__weekDays">{weekdays}</div>
+    const toggleMonthSelector = createStateToggler('isMonthSelectorOpen');
+    const toggleYearSelector = createStateToggler('isYearSelectorOpen');
 
-      <DaysList
-        activeDate={activeDate}
-        value={value}
-        monthChangeDirection={mainState.monthChangeDirection}
-        onSlideChange={updateDate}
-        disabledDays={disabledDays}
-        onDisabledDayError={onDisabledDayError}
-        minimumDate={minimumDate}
-        maximumDate={maximumDate}
-        onChange={onChange}
-        calendarTodayClassName={calendarTodayClassName}
-        calendarSelectedDayClassName={calendarSelectedDayClassName}
-        calendarRangeStartClassName={calendarRangeStartClassName}
-        calendarRangeEndClassName={calendarRangeEndClassName}
-        calendarRangeBetweenClassName={calendarRangeBetweenClassName}
-        locale={locale}
-        shouldHighlightWeekends={shouldHighlightWeekends}
-        customDaysClassName={customDaysClassName}
-        isQuickSelectorOpen={mainState.isYearSelectorOpen || mainState.isMonthSelectorOpen}
-      />
-      <div className="Calendar__footer">{renderFooter()}</div>
-    </div>
-  );
-};
+    const getComputedActiveDate = () => {
+      const valueType = getValueType(value);
+      if (valueType === TYPE_MUTLI_DATE && value.length) return shallowClone(value[0]);
+      if (valueType === TYPE_SINGLE_DATE && value) return shallowClone(value);
+      if (valueType === TYPE_RANGE && value.from) return shallowClone(value.from);
+      return shallowClone(today);
+    };
+
+    const activeDate = mainState.activeDate
+      ? shallowClone(mainState.activeDate)
+      : getComputedActiveDate();
+
+    const weekdays = weekDaysList.map(weekDay => (
+      <abbr key={weekDay.name} title={weekDay.name} className="Calendar__weekDay">
+        {weekDay.short}
+      </abbr>
+    ));
+
+    const handleMonthChange = direction => {
+      setMainState({
+        ...mainState,
+        monthChangeDirection: direction,
+      });
+      if (onDisplayedDateChangeStart) {
+        onDisplayedDateChangeStart({
+          direction,
+          currentDate: activeDate,
+          nextDate: getDateAccordingToMonth(activeDate, direction),
+        });
+      }
+    };
+
+    const updateDate = () => {
+      const newActiveDate = getDateAccordingToMonth(activeDate, mainState.monthChangeDirection);
+      setMainState({
+        ...mainState,
+        activeDate: newActiveDate,
+        monthChangeDirection: '',
+      });
+      if (onDisplayedDateChangeEnd) {
+        onDisplayedDateChangeEnd(newActiveDate);
+      }
+    };
+
+    const selectMonth = newMonthNumber => {
+      const newActiveDate = { ...activeDate, month: newMonthNumber };
+      setMainState({
+        ...mainState,
+        activeDate: newActiveDate,
+        isMonthSelectorOpen: false,
+      });
+      if (onDisplayedDateChangeEnd) {
+        onDisplayedDateChangeEnd(newActiveDate);
+      }
+    };
+
+    const selectYear = year => {
+      const newActiveDate = { ...activeDate, year };
+      setMainState({
+        ...mainState,
+        activeDate: newActiveDate,
+        isYearSelectorOpen: false,
+      });
+      if (onDisplayedDateChangeEnd) {
+        onDisplayedDateChangeEnd(newActiveDate);
+      }
+    };
+
+    useImperativeHandle(ref, () => ({
+      selectMonth: val => {
+        if (typeof val === 'string') handleMonthChange(val);
+        else selectMonth(val);
+      },
+      selectYear,
+    }));
+
+    return (
+      <div
+        className={`Calendar -noFocusOutline ${calendarClassName} -${isRtl ? 'rtl' : 'ltr'}`}
+        role="grid"
+        style={{
+          '--cl-color-primary': colorPrimary,
+          '--cl-color-primary-light': colorPrimaryLight,
+          '--animation-duration': slideAnimationDuration,
+        }}
+        ref={calendarElement}
+      >
+        <Header
+          maximumDate={maximumDate}
+          minimumDate={minimumDate}
+          activeDate={activeDate}
+          onMonthChange={handleMonthChange}
+          onMonthSelect={toggleMonthSelector}
+          onYearSelect={toggleYearSelector}
+          monthChangeDirection={mainState.monthChangeDirection}
+          isMonthSelectorOpen={mainState.isMonthSelectorOpen}
+          isYearSelectorOpen={mainState.isYearSelectorOpen}
+          locale={locale}
+        />
+
+        <MonthSelector
+          isOpen={mainState.isMonthSelectorOpen}
+          activeDate={activeDate}
+          onMonthSelect={selectMonth}
+          maximumDate={maximumDate}
+          minimumDate={minimumDate}
+          locale={locale}
+        />
+
+        <YearSelector
+          isOpen={mainState.isYearSelectorOpen}
+          activeDate={activeDate}
+          onYearSelect={selectYear}
+          selectorStartingYear={selectorStartingYear}
+          selectorEndingYear={selectorEndingYear}
+          maximumDate={maximumDate}
+          minimumDate={minimumDate}
+          locale={locale}
+        />
+
+        <div className="Calendar__weekDays">{weekdays}</div>
+
+        <DaysList
+          activeDate={activeDate}
+          value={value}
+          monthChangeDirection={mainState.monthChangeDirection}
+          onSlideChange={updateDate}
+          disabledDays={disabledDays}
+          onDisabledDayError={onDisabledDayError}
+          minimumDate={minimumDate}
+          maximumDate={maximumDate}
+          onChange={onChange}
+          calendarTodayClassName={calendarTodayClassName}
+          calendarSelectedDayClassName={calendarSelectedDayClassName}
+          calendarRangeStartClassName={calendarRangeStartClassName}
+          calendarRangeEndClassName={calendarRangeEndClassName}
+          calendarRangeBetweenClassName={calendarRangeBetweenClassName}
+          locale={locale}
+          shouldHighlightWeekends={shouldHighlightWeekends}
+          customDaysClassName={customDaysClassName}
+          isQuickSelectorOpen={mainState.isYearSelectorOpen || mainState.isMonthSelectorOpen}
+        />
+        <div className="Calendar__footer">{renderFooter()}</div>
+      </div>
+    );
+  },
+);
 
 Calendar.defaultProps = {
   minimumDate: null,

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -8,6 +8,8 @@ import { TYPE_SINGLE_DATE, TYPE_MUTLI_DATE, TYPE_RANGE } from './shared/constant
 const DatePicker = ({
   value,
   onChange,
+  onDisplayedDateChangeEnd,
+  onDisplayedDateChangeStart,
   formatInputText,
   inputPlaceholder,
   inputClassName,
@@ -34,6 +36,7 @@ const DatePicker = ({
   shouldHighlightWeekends,
   renderFooter,
   customDaysClassName,
+  calendarRef,
 }) => {
   const calendarContainerElement = useRef(null);
   const inputElement = useRef(null);
@@ -164,8 +167,11 @@ const DatePicker = ({
             }}
           >
             <Calendar
+              ref={calendarRef}
               value={value}
               onChange={handleCalendarChange}
+              onDisplayedDateChangeEnd={onDisplayedDateChangeEnd}
+              onDisplayedDateChangeStart={onDisplayedDateChangeStart}
               calendarClassName={calendarClassName}
               calendarTodayClassName={calendarTodayClassName}
               calendarSelectedDayClassName={calendarSelectedDayClassName}


### PR DESCRIPTION
Solves #202 

This pull request adds support of two callbacks on Calendar and DatePicker components.

`onDisplayedDateChangeStart` will be fired when transition to new month starts, or new month/year is selected from dropdown.
`onDisplayedDateChangeEnd` will be fired when transition to new month ends, or new month/year is selected from dropdown.

This pull request also adds ref to Calendar (and calendarRef to DatePicker), by which it will be possible to change displayed year and month simply by calling `selectYear` or `selectMonth`. In case of `selectMonth`, it is also possible to pass "NEXT" and "PREVIOUS" strings.