### PR TITLE
Ref calendarElement is null causes "Cannot read property 'removeEventListener' of null" #204

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modern-calendar-datepicker",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -38,7 +38,7 @@ const Calendar = ({
   });
 
   useEffect(() => {
-    if (calendarElement === null) {
+    if (calendarElement.current === null) {
       return;
     }
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -38,6 +38,10 @@ const Calendar = ({
   });
 
   useEffect(() => {
+    if (calendarElement === null) {
+      return;
+    }
+
     const handleKeyUp = ({ key }) => {
       /* istanbul ignore else */
       if (key === 'Tab') calendarElement.current.classList.remove('-noFocusOutline');
@@ -46,7 +50,7 @@ const Calendar = ({
     return () => {
       calendarElement.current.removeEventListener('keyup', handleKeyUp, false);
     };
-  });
+  }, [calendarElement]);
 
   const { getToday } = useLocaleUtils(locale);
   const { weekDays: weekDaysList, isRtl } = useLocaleLanguage(locale);

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -48,7 +48,9 @@ const Calendar = ({
     };
     calendarElement.current.addEventListener('keyup', handleKeyUp, false);
     return () => {
-      calendarElement.current.removeEventListener('keyup', handleKeyUp, false);
+      if (calendarElement.current !== null) {
+        calendarElement.current.removeEventListener('keyup', handleKeyUp, false);
+      }
     };
   }, [calendarElement]);
 


### PR DESCRIPTION
https://github.com/Kiarash-Z/react-modern-calendar-datepicker/issues/204