### PR TITLE
Check if calendarElement is not null before adding or removing its event listeners

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -42,11 +42,19 @@ const Calendar = ({
       /* istanbul ignore else */
       if (key === 'Tab') calendarElement.current.classList.remove('-noFocusOutline');
     };
-    calendarElement.current.addEventListener('keyup', handleKeyUp, false);
+
+    /* istanbul ignore else */
+    if (calendarElement.current !== null) {
+      calendarElement.current.addEventListener('keyup', handleKeyUp, false);
+    }
+
     return () => {
-      calendarElement.current.removeEventListener('keyup', handleKeyUp, false);
+      /* istanbul ignore else */
+      if (calendarElement.current !== null) {
+        calendarElement.current.removeEventListener('keyup', handleKeyUp, false);
+      }
     };
-  });
+  }, [calendarElement]);
 
   const { getToday } = useLocaleUtils(locale);
   const { weekDays: weekDaysList, isRtl } = useLocaleLanguage(locale);


### PR DESCRIPTION
It's a fix for #204 issue.