### PR TITLE
Added month picker

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,8 +14,11 @@ type Value = DayValue | Day[] | DayRange;
 
 type CustomDayClassNameItem = Day & { className: string };
 
+type PickerType = "month" | "date";
+
 export interface CalendarProps<TValue extends Value> {
   value: TValue;
+  picker?: PickerType;
   onChange?(value: TValue): void;
   onDisabledDayError?(value: Day): void;
   selectorStartingYear?: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modern-calendar-datepicker",
-  "version": "3.2",
+  "version": "3.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modern-calendar-datepicker",
-  "version": "3.1.5",
+  "version": "3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-modern-calendar-datepicker",
-  "version": "3.1.6",
+  "name": "react-modern-calendar-datepicker-monthpicker-fork",
+  "version": "3.2.2",
   "description": "A modern, beautiful, customizable date picker for React",
   "main": "lib/index.js",
   "types": "index.d.ts",
@@ -24,7 +24,7 @@
   "homepage": "https://kiarash-z.github.io/react-modern-calendar-datepicker",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Kiarash-Z/react-modern-calendar-datepicker.git"
+    "url": "https://github.com/kianoosh76/react-modern-calendar-datepicker.git"
   },
   "bugs": {
     "url": "https://github.com/Kiarash-Z/react-modern-calendar-datepicker/issues"

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -99,7 +99,7 @@ const Calendar = ({
       activeDate: { ...activeDate, month: newMonthNumber },
       isMonthSelectorOpen: false,
     });
-    onChange({ year: activeDate.year, month: newMonthNumber, day: 1 });
+    if (picker === PICKER_MONTH) onChange({ year: activeDate.year, month: newMonthNumber, day: 1 });
   };
 
   const selectYear = year => {

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -188,6 +188,7 @@ const Calendar = ({
 };
 
 Calendar.defaultProps = {
+  onChange: () => {},
   minimumDate: null,
   maximumDate: null,
   colorPrimary: '#0eca2d',

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 
 import { getDateAccordingToMonth, shallowClone, getValueType } from './shared/generalUtils';
-import { TYPE_SINGLE_DATE, TYPE_RANGE, TYPE_MUTLI_DATE } from './shared/constants';
+import { TYPE_SINGLE_DATE, TYPE_RANGE, TYPE_MUTLI_DATE, PICKER_MONTH } from './shared/constants';
 import { useLocaleUtils, useLocaleLanguage } from './shared/hooks';
 
 import { Header, MonthSelector, YearSelector, DaysList } from './components';
@@ -28,12 +28,13 @@ const Calendar = ({
   shouldHighlightWeekends,
   renderFooter,
   customDaysClassName,
+  picker,
 }) => {
   const calendarElement = useRef(null);
   const [mainState, setMainState] = useState({
     activeDate: null,
     monthChangeDirection: '',
-    isMonthSelectorOpen: false,
+    isMonthSelectorOpen: picker === PICKER_MONTH,
     isYearSelectorOpen: false,
   });
 
@@ -98,6 +99,7 @@ const Calendar = ({
       activeDate: { ...activeDate, month: newMonthNumber },
       isMonthSelectorOpen: false,
     });
+    onChange({ year: activeDate.year, month: newMonthNumber, day: 1 });
   };
 
   const selectYear = year => {
@@ -130,6 +132,7 @@ const Calendar = ({
         isMonthSelectorOpen={mainState.isMonthSelectorOpen}
         isYearSelectorOpen={mainState.isYearSelectorOpen}
         locale={locale}
+        picker={picker}
       />
 
       <MonthSelector
@@ -152,29 +155,34 @@ const Calendar = ({
         locale={locale}
       />
 
-      <div className="Calendar__weekDays">{weekdays}</div>
-
-      <DaysList
-        activeDate={activeDate}
-        value={value}
-        monthChangeDirection={mainState.monthChangeDirection}
-        onSlideChange={updateDate}
-        disabledDays={disabledDays}
-        onDisabledDayError={onDisabledDayError}
-        minimumDate={minimumDate}
-        maximumDate={maximumDate}
-        onChange={onChange}
-        calendarTodayClassName={calendarTodayClassName}
-        calendarSelectedDayClassName={calendarSelectedDayClassName}
-        calendarRangeStartClassName={calendarRangeStartClassName}
-        calendarRangeEndClassName={calendarRangeEndClassName}
-        calendarRangeBetweenClassName={calendarRangeBetweenClassName}
-        locale={locale}
-        shouldHighlightWeekends={shouldHighlightWeekends}
-        customDaysClassName={customDaysClassName}
-        isQuickSelectorOpen={mainState.isYearSelectorOpen || mainState.isMonthSelectorOpen}
-      />
-      <div className="Calendar__footer">{renderFooter()}</div>
+      {picker !== PICKER_MONTH ? (
+        <>
+          <div className="Calendar__weekDays">{weekdays}</div>
+          <DaysList
+            activeDate={activeDate}
+            value={value}
+            monthChangeDirection={mainState.monthChangeDirection}
+            onSlideChange={updateDate}
+            disabledDays={disabledDays}
+            onDisabledDayError={onDisabledDayError}
+            minimumDate={minimumDate}
+            maximumDate={maximumDate}
+            onChange={onChange}
+            calendarTodayClassName={calendarTodayClassName}
+            calendarSelectedDayClassName={calendarSelectedDayClassName}
+            calendarRangeStartClassName={calendarRangeStartClassName}
+            calendarRangeEndClassName={calendarRangeEndClassName}
+            calendarRangeBetweenClassName={calendarRangeBetweenClassName}
+            locale={locale}
+            shouldHighlightWeekends={shouldHighlightWeekends}
+            customDaysClassName={customDaysClassName}
+            isQuickSelectorOpen={mainState.isYearSelectorOpen || mainState.isMonthSelectorOpen}
+          />
+          <div className="Calendar__footer">{renderFooter()}</div>
+        </>
+      ) : (
+        <></>
+      )}
     </div>
   );
 };

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -7,6 +7,7 @@ import { TYPE_SINGLE_DATE, TYPE_MUTLI_DATE, TYPE_RANGE } from './shared/constant
 
 const DatePicker = ({
   value,
+  picker,
   onChange,
   formatInputText,
   inputPlaceholder,
@@ -165,6 +166,7 @@ const DatePicker = ({
           >
             <Calendar
               value={value}
+              picker={picker}
               onChange={handleCalendarChange}
               calendarClassName={calendarClassName}
               calendarTodayClassName={calendarTodayClassName}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,6 +3,7 @@ import React, { useEffect, useRef } from 'react';
 import { isSameDay } from '../shared/generalUtils';
 import { getSlideDate, animateContent, handleSlideAnimationEnd } from '../shared/sliderHelpers';
 import { useLocaleUtils, useLocaleLanguage } from '../shared/hooks';
+import { PICKER_MONTH } from '../shared/constants';
 
 const Header = ({
   maximumDate,
@@ -15,6 +16,7 @@ const Header = ({
   isMonthSelectorOpen,
   isYearSelectorOpen,
   locale,
+  picker,
 }) => {
   const headerElement = useRef(null);
   const monthYearWrapperElement = useRef(null);
@@ -39,6 +41,8 @@ const Header = ({
   }, [monthChangeDirection]);
 
   useEffect(() => {
+    if (picker === PICKER_MONTH) return;
+
     const isOpen = isMonthSelectorOpen || isYearSelectorOpen;
     const monthText = headerElement.current.querySelector(
       '.Calendar__monthYear.-shown .Calendar__monthText',
@@ -152,17 +156,21 @@ const Header = ({
 
   return (
     <div ref={headerElement} className="Calendar__header">
-      <button
-        className="Calendar__monthArrowWrapper -right"
-        onClick={() => {
-          onMonthChangeTrigger('PREVIOUS');
-        }}
-        aria-label={previousMonth}
-        type="button"
-        disabled={isPreviousMonthArrowDisabled}
-      >
-        <span className="Calendar__monthArrow" />
-      </button>
+      {picker !== PICKER_MONTH ? (
+        <button
+          className="Calendar__monthArrowWrapper -right"
+          onClick={() => {
+            onMonthChangeTrigger('PREVIOUS');
+          }}
+          aria-label={previousMonth}
+          type="button"
+          disabled={isPreviousMonthArrowDisabled}
+        >
+          <span className="Calendar__monthArrow" />
+        </button>
+      ) : (
+        <></>
+      )}
       <div
         className="Calendar__monthYearContainer"
         ref={monthYearWrapperElement}
@@ -171,17 +179,21 @@ const Header = ({
         &nbsp;
         {monthYearButtons}
       </div>
-      <button
-        className="Calendar__monthArrowWrapper -left"
-        onClick={() => {
-          onMonthChangeTrigger('NEXT');
-        }}
-        aria-label={nextMonth}
-        type="button"
-        disabled={isNextMonthArrowDisabled}
-      >
-        <span className="Calendar__monthArrow" />
-      </button>
+      {picker !== PICKER_MONTH ? (
+        <button
+          className="Calendar__monthArrowWrapper -left"
+          onClick={() => {
+            onMonthChangeTrigger('NEXT');
+          }}
+          aria-label={nextMonth}
+          type="button"
+          disabled={isNextMonthArrowDisabled}
+        >
+          <span className="Calendar__monthArrow" />
+        </button>
+      ) : (
+        <></>
+      )}
     </div>
   );
 };

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -102,3 +102,6 @@ export const MAXIMUM_SELECTABLE_YEAR_SUM = 50;
 export const TYPE_SINGLE_DATE = 'SINGLE_DATE';
 export const TYPE_RANGE = 'RANGE';
 export const TYPE_MUTLI_DATE = 'MUTLI_DATE';
+
+export const PICKER_DATE = 'date';
+export const PICKER_MONTH = 'month';


### PR DESCRIPTION
This pull request implements monthPicker; by passing `picker="month"`, the date picker dismisses sending the first date of the month as the output. Moreover, header has changed so that in this case, both month and year always stay in there.